### PR TITLE
Support Ssl and Basic Auth. Configurable to accept self-signed server cert

### DIFF
--- a/src/log4net.ElasticSearch/ElasticClient.cs
+++ b/src/log4net.ElasticSearch/ElasticClient.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Web.Script.Serialization;
 
@@ -11,6 +13,10 @@ namespace log4net.ElasticSearch
     {
         string Server { get; }
         int Port { get; }
+        bool Ssl { get; }
+        bool AllowSelfSignedServerCert { get; }
+        string BasicAuthUsername { get; }
+        string BasicAuthPassword { get; }
         void PutTemplateRaw(string templateName, string rawBody);
         void IndexBulk(IEnumerable<InnerBulkOperation> bulk);
         IAsyncResult IndexBulkAsync(IEnumerable<InnerBulkOperation> bulk);
@@ -27,15 +33,39 @@ namespace log4net.ElasticSearch
     {
         public string Server { get; private set; }
         public int Port { get; private set; }
+        public bool Ssl { get; private set; }
+        public bool AllowSelfSignedServerCert { get; private set; }
+        public string BasicAuthUsername { get; private set; }
+        public string BasicAuthPassword { get; private set; }
 
-        private readonly string _url;
+        private string _url { 
+            get 
+            {
+                return string.Format("{0}://{1}:{2}/", Ssl ? "https" : "http", Server, Port);
+            }
+        }
 
         public WebElasticClient(string server, int port)
         {
             Server = server;
             Port = port;
-            _url = string.Format("http://{0}:{1}/", Server, Port);
             ServicePointManager.Expect100Continue = false;
+        }
+
+        public WebElasticClient(string server, int port,
+                                bool ssl, bool allowSelfSignedServerCert, 
+                                string basicAuthUsername, string basicAuthPassword)
+            : this(server, port)
+        {
+            Ssl = ssl;
+            AllowSelfSignedServerCert = allowSelfSignedServerCert;
+            BasicAuthPassword = basicAuthPassword;
+            BasicAuthUsername = basicAuthUsername;
+
+            if (true == Ssl && true == AllowSelfSignedServerCert)
+            {
+                AcceptSelfSignedServerCert(server);
+            }
         }
 
         public void PutTemplateRaw(string templateName, string rawBody)
@@ -43,6 +73,7 @@ namespace log4net.ElasticSearch
             var webRequest = WebRequest.Create(string.Concat(_url, "_template/", templateName));
             webRequest.ContentType = "text/json";
             webRequest.Method = "PUT";
+            SetBasicAuthHeader(webRequest, BasicAuthUsername, BasicAuthPassword);
             SendRequest(webRequest, rawBody);
             using (var httpResponse = (HttpWebResponse)webRequest.GetResponse())
             {
@@ -82,7 +113,7 @@ namespace log4net.ElasticSearch
             webRequest.ContentType = "text/plain";
             webRequest.Method = "POST";
             webRequest.Timeout = 10000;
-
+            SetBasicAuthHeader(webRequest, BasicAuthUsername, BasicAuthPassword);
             SendRequest(webRequest, requestString);
             return webRequest;
         }
@@ -111,6 +142,38 @@ namespace log4net.ElasticSearch
             {
                 stream.Write(requestString);
             }
+        }
+
+        private static void SetBasicAuthHeader(WebRequest request, string username, string password)
+        {
+            if (false == string.IsNullOrEmpty(username)) /* IsNullOrWhiteSpace will be better, but .Net 3.5 doesn't support IsNullOrWhiteSpace but only IsNullOrEmpty */
+            {
+                string authInfo = string.Format("{0}:{1}", username, password);
+                string encodedAuthInfo = Convert.ToBase64String(Encoding.ASCII.GetBytes(authInfo));
+                string credentials = string.Format("{0} {1}", "Basic", encodedAuthInfo);
+                request.Headers[HttpRequestHeader.Authorization] = credentials;
+            }
+        }
+
+        private static void AcceptSelfSignedServerCert(string server)
+        {
+            ServicePointManager.ServerCertificateValidationCallback +=
+                new System.Net.Security.RemoteCertificateValidationCallback(
+                delegate(Object sender,
+                          X509Certificate certificate,
+                          X509Chain chain,
+                          SslPolicyErrors sslPolicyErrors)
+                {
+                    string subjectCN = (certificate as X509Certificate2).GetNameInfo(X509NameType.DnsName, false);
+                    string issuerCN = (certificate as X509Certificate2).GetNameInfo(X509NameType.DnsName, true);
+                    if (sslPolicyErrors == SslPolicyErrors.None
+                        || (server.Equals(subjectCN) && subjectCN.Equals(issuerCN)))
+                    {
+                        return true;
+                    }
+                    else
+                        return false;
+                });
         }
 
         private static void CheckResponse(HttpWebResponse httpResponse)

--- a/src/log4net.ElasticSearch/ElasticSearchAppender.cs
+++ b/src/log4net.ElasticSearch/ElasticSearchAppender.cs
@@ -30,6 +30,10 @@ namespace log4net.ElasticSearch
         // elastic configuration
         public string Server { get; set; }
         public int Port { get; set; }
+        public bool Ssl { get; set; }
+        public bool AllowSelfSignedServerCert { get; set; }
+        public string BasicAuthUsername { get; set; }
+        public string BasicAuthPassword { get; set; }
         public bool IndexAsync { get; set; }
         public int MaxAsyncConnections { get; set; }
         public TemplateInfo Template { get; set; }
@@ -67,7 +71,7 @@ namespace log4net.ElasticSearch
 
         public override void ActivateOptions()
         {
-            _client = new WebElasticClient(Server, Port);
+            _client = new WebElasticClient(Server, Port, Ssl, AllowSelfSignedServerCert, BasicAuthUsername, BasicAuthPassword);
 
             if (Template != null && Template.IsValid)
             {


### PR DESCRIPTION
I have put my elasticsearch behind nginx. I turned on ssl and basic auth in nginx. So I added ssl and basic auth support in log4stash to support that kind of setup. In addition, I am using a self-signed server cert at this stage. So I added the AllowSelfSignedServerCert property to accommodate such need. 

The two methods that I added, SetBasicAuthHeader() and AcceptSelfSignedServerCert(), are tested against my own elasticsearch setup. I am not sure how to unit test them. I've used the log4stash with ssl and basic auth support in my own project. It seems working well. 
